### PR TITLE
Refactor/제약조건수정

### DIFF
--- a/game/domain/game.py
+++ b/game/domain/game.py
@@ -8,6 +8,7 @@ class Game(models.Model):
     sport = models.ForeignKey(Sport, models.DO_NOTHING)
     member = models.ForeignKey(Member, models.DO_NOTHING)
     league = models.ForeignKey(League, models.DO_NOTHING)
+    name = models.CharField(max_length=255)
     start_time = models.DateTimeField()
     video_id = models.CharField(max_length=255, blank=True, null=True)
     quarter_changed_at = models.DateTimeField()

--- a/game/domain/game.py
+++ b/game/domain/game.py
@@ -4,6 +4,11 @@ from accounts.domain import Member
 from league.domain import League
 
 class Game(models.Model):
+    GAME_CHOICES = (
+        ('PLAYING', 'playing'),
+        ('FINISHED','finished'),
+        ('SCHEDULED', 'scheduled'),
+    )
     id = models.BigAutoField(primary_key=True)
     sport = models.ForeignKey(Sport, models.DO_NOTHING)
     member = models.ForeignKey(Member, models.DO_NOTHING)
@@ -13,6 +18,7 @@ class Game(models.Model):
     video_id = models.CharField(max_length=255, blank=True, null=True)
     quarter_changed_at = models.DateTimeField()
     game_quarter = models.CharField(max_length=255)
+    state = models.CharField(max_length=255, choices=GAME_CHOICES)
 
     class Meta:
         managed = False

--- a/game/domain/game.py
+++ b/game/domain/game.py
@@ -11,7 +11,7 @@ class Game(models.Model):
     )
     id = models.BigAutoField(primary_key=True)
     sport = models.ForeignKey(Sport, models.DO_NOTHING)
-    member = models.ForeignKey(Member, models.DO_NOTHING)
+    administrator = models.ForeignKey(Member, models.DO_NOTHING)
     league = models.ForeignKey(League, models.DO_NOTHING)
     name = models.CharField(max_length=255)
     start_time = models.DateTimeField()

--- a/league/domain/league.py
+++ b/league/domain/league.py
@@ -6,6 +6,7 @@ class League(models.Model):
     administrator = models.ForeignKey(Member, models.DO_NOTHING)
     organization = models.ForeignKey(Organization, models.DO_NOTHING)
     name = models.CharField(max_length=255)
+    is_deleted = models.BooleanField(default=False)
     start_at = models.DateTimeField()
     end_at = models.DateTimeField()
 

--- a/report/domain/comment.py
+++ b/report/domain/comment.py
@@ -6,7 +6,7 @@ class Comment(models.Model):
     created_at = models.DateTimeField()
     content = models.CharField(max_length=255)
     is_blocked = models.BooleanField(default=False)
-    game_team = models.ForeignKey(GameTeam, models.DO_NOTHING)
+    game_team_id = models.BigIntegerField()
 
     class Meta:
         managed = False

--- a/report/domain/report.py
+++ b/report/domain/report.py
@@ -1,11 +1,17 @@
 from django.db import models
 from report.domain import Comment
 
-class Report(models.Model): 
+class Report(models.Model):
+    REPORT_STATE_CHOICES = (
+        ('UNCHECKED', 'unchecked'),
+        ('VALID','valid'),
+        ('INVALID', 'invalid'),
+        ('PENDING', 'pending')
+    )
     id = models.BigAutoField(primary_key=True)
     comment = models.ForeignKey(Comment, models.DO_NOTHING)
     reported_at = models.DateTimeField()
-    is_valid = models.BooleanField(default=False)
+    state = models.CharField(max_length=255, choices=REPORT_STATE_CHOICES)
 
     class Meta:
         managed = False

--- a/report/domain/report.py
+++ b/report/domain/report.py
@@ -9,7 +9,7 @@ class Report(models.Model):
         ('PENDING', 'pending')
     )
     id = models.BigAutoField(primary_key=True)
-    comment = models.ForeignKey(Comment, models.DO_NOTHING)
+    comment = models.ForeignKey(Comment, models.DO_NOTHING, unique=True)
     reported_at = models.DateTimeField()
     state = models.CharField(max_length=255, choices=REPORT_STATE_CHOICES)
 


### PR DESCRIPTION
### 이슈번호
- #30 
### 작업한 내용
- comments -> game_teams 외래키 제약 제거
- comments.game_team_id에 인덱스 추가
- games에 name 추가
- games에 member_id -> administrator_id로 변경
- reports에 state 칼럼 추가 및 is_valid 삭제
- games에 state 칼럼 추가
- league에 is_deleted 추가